### PR TITLE
build: publish Python packages with uv directly

### DIFF
--- a/.github/workflows/python_antlr.yml
+++ b/.github/workflows/python_antlr.yml
@@ -126,15 +126,20 @@ jobs:
         with:
           ref: ${{ env.TAG_NAME }}
           fetch-depth: 0
-      - name: Install pixi
-        uses: prefix-dev/setup-pixi@v0.9.4
+      - name: Install Python
+        uses: actions/setup-python@v6
         with:
-          pixi-version: v0.62.2
+          python-version: '3.x'
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          # Pin uv version
+          version: "0.9.25"
       - name: Build
-        run: pixi run uv build
+        run: uv build
       - name: Smoke Test (wheel)
-        run: pixi run uv run --isolated --no-project --with dist/*.whl tests/test_antlr.py
+        run: uv run --isolated --no-project --with dist/*.whl tests/test_antlr.py
       - name: Smoke Test (source distribution)
-        run: pixi run uv run --isolated --no-project --with dist/*.tar.gz tests/test_antlr.py
+        run: uv run --isolated --no-project --with dist/*.tar.gz tests/test_antlr.py
       - name: Publish
-        run: pixi run uv publish --index testpypi
+        run: uv publish --index testpypi

--- a/.github/workflows/python_protobuf.yml
+++ b/.github/workflows/python_protobuf.yml
@@ -127,15 +127,20 @@ jobs:
         with:
           ref: ${{ env.TAG_NAME }}
           fetch-depth: 0
-      - name: Install pixi
-        uses: prefix-dev/setup-pixi@v0.9.4
+      - name: Install Python
+        uses: actions/setup-python@v6
         with:
-          pixi-version: v0.62.2
+          python-version: '3.x'
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          # Pin uv version
+          version: "0.9.25"
       - name: Build
-        run: pixi run uv build
+        run: uv build
       - name: Smoke Test (wheel)
-        run: pixi run uv run --isolated --no-project --with dist/*.whl tests/test_proto.py
+        run: uv run --isolated --no-project --with dist/*.whl tests/test_proto.py
       - name: Smoke Test (source distribution)
-        run: pixi run uv run --isolated --no-project --with dist/*.tar.gz tests/test_proto.py
+        run: uv run --isolated --no-project --with dist/*.tar.gz tests/test_proto.py
       - name: Publish
-        run: pixi run uv publish
+        run: uv publish


### PR DESCRIPTION
There is some weirdness publishing to TestPyPI (https://github.com/substrait-io/substrait-packaging/actions/runs/22493496397/job/65161803198) that started happening after I switched the publishing step to use PIXI. This PR switches just the publishing back to using `uv` installed directly in the Github Action.