### PR TITLE
ci(python): publish substrait-extensions

### DIFF
--- a/.github/workflows/python_extensions.yml
+++ b/.github/workflows/python_extensions.yml
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [python-extensions-prechecks, python-extensions-generate]
     if: needs.python-extensions-prechecks.outputs.artifact_exists == 'false'
-    environment: testpypi
+    environment: pypi
     permissions:
       id-token: write
       contents: read
@@ -143,4 +143,4 @@ jobs:
       - name: Smoke Test (source distribution)
         run: uv run --isolated --no-project --with dist/*.tar.gz tests/test_extensions.py
       - name: Publish
-        run: uv publish --index testpypi
+        run: uv publish

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Artifacts are generated and published using a hierarchy of GitHub Actions:
   * python_publish.yml: For releasing Python specific artifacts
     * python_antlr.yml
     * python_protobuf.yml
-    * ...
+    * python_extensions.yml
   * TODO: rust_publish.yml: For releasing Rust specific artifacts
     * ...
 
@@ -36,9 +36,12 @@ pixi install
 ## Python Code Generation
 
 ```sh
-# Generate ANTLR Python parsers
+# Generate substrait-antlr Python Package
 pixi run python-generate-antlr
 
-# Generate protobuf Python bindings
+# Generate substrait-protobuf Python Package
 pixi run python-generate-protobuf
+
+# Generate substrait-extensions Python Package
+pixi run python-generate-extensions
 ```

--- a/python/substrait-extensions/pyproject.toml
+++ b/python/substrait-extensions/pyproject.toml
@@ -33,12 +33,6 @@ namespaces = true
 "substrait_extensions.extensions" = ["*.yaml"]
 "substrait_extensions.testcases" = ["*/*.test"]
 
-[[tool.uv.index]]
-name = "testpypi"
-url = "https://test.pypi.org/simple/"
-publish-url = "https://test.pypi.org/legacy/"
-explicit = true
-
 [build-system]
 requires = ["setuptools>=80"]
 build-backend = "setuptools.build_meta"

--- a/python/substrait-extensions/tests/test_extensions.py
+++ b/python/substrait-extensions/tests/test_extensions.py
@@ -1,13 +1,10 @@
 from importlib.resources import files
 
-
 def test_simple_extensions_datamodel():
     from substrait_extensions.extensions.simple_extensions import SimpleExtensions
 
-
 def test_dialect_dataclasses():
     from substrait_extensions.dialects.dialect import Dialect
-
 
 def test_extension_file_access():
     data = files("substrait_extensions.extensions").joinpath("functions_arithmetic.yaml").read_text()
@@ -19,7 +16,6 @@ def test_extension_file_access():
 def test_dialect_file_access():
     data = files("substrait_extensions.dialects").joinpath("dialect_schema.yaml").read_text()
     assert len(data) > 0
-
 
 def test_testcase_files_accessible():
     data = files("substrait_extensions.testcases").joinpath("arithmetic").joinpath("add.test").read_text()


### PR DESCRIPTION
Generated a tag for v0.79.0. Workflow runs as expected and only fails at the [publish step](https://github.com/substrait-io/substrait-packaging/actions/runs/23030301172).

The tag produced looks good: https://github.com/substrait-io/substrait-packaging/tree/python/substrait-extensions/v0.79.0/python/substrait-extensions