### PR TITLE
ci: use client-id to fetch GitHub app token

### DIFF
--- a/.github/workflows/python_antlr.yml
+++ b/.github/workflows/python_antlr.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.PACKAGER_ID }}
+          client-id: ${{ vars.PACKAGER_CLIENT_ID }}
           private-key: ${{ secrets.PACKAGER_KEY }}
 
       - name: Get GitHub App User ID

--- a/.github/workflows/python_extensions.yml
+++ b/.github/workflows/python_extensions.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.PACKAGER_ID }}
+          client-id: ${{ vars.PACKAGER_CLIENT_ID }}
           private-key: ${{ secrets.PACKAGER_KEY }}
 
       - name: Get GitHub App User ID

--- a/.github/workflows/python_protobuf.yml
+++ b/.github/workflows/python_protobuf.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.PACKAGER_ID }}
+          client-id: ${{ vars.PACKAGER_CLIENT_ID }}
           private-key: ${{ secrets.PACKAGER_KEY }}
 
       - name: Get GitHub App User ID


### PR DESCRIPTION
Looks like app-id is being deprecated.

<img width="529" height="223" alt="Screenshot 2026-05-11 at 15 57 26" src="https://github.com/user-attachments/assets/63287cde-3eae-41ae-8eb7-5d40ac7e7dd7" />

I've added the Substrait Package app Client ID as a secret.
<img width="186" height="44" alt="Screenshot 2026-05-11 at 16 00 12" src="https://github.com/user-attachments/assets/e0f7a78b-db0a-4b81-9f3f-1f9bdd748d32" />
