### PR TITLE
ci: reference PACKAGER_CLIENT_ID as secret

### DIFF
--- a/.github/workflows/python_antlr.yml
+++ b/.github/workflows/python_antlr.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          client-id: ${{ vars.PACKAGER_CLIENT_ID }}
+          client-id: ${{ secrets.PACKAGER_CLIENT_ID }}
           private-key: ${{ secrets.PACKAGER_KEY }}
 
       - name: Get GitHub App User ID

--- a/.github/workflows/python_extensions.yml
+++ b/.github/workflows/python_extensions.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          client-id: ${{ vars.PACKAGER_CLIENT_ID }}
+          client-id: ${{ secrets.PACKAGER_CLIENT_ID }}
           private-key: ${{ secrets.PACKAGER_KEY }}
 
       - name: Get GitHub App User ID

--- a/.github/workflows/python_protobuf.yml
+++ b/.github/workflows/python_protobuf.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          client-id: ${{ vars.PACKAGER_CLIENT_ID }}
+          client-id: ${{ secrets.PACKAGER_CLIENT_ID }}
           private-key: ${{ secrets.PACKAGER_KEY }}
 
       - name: Get GitHub App User ID


### PR DESCRIPTION
`PACKAGER_CLIENT_ID` is a secret so we need to reference it as a secret and not as a variable.

This currently breaks the builds: https://github.com/substrait-io/substrait-packaging/actions/runs/26824815713/job/79089169016