### PR TITLE
ci: validate Python and Rust packaging against latest spec release

### DIFF
--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -1,0 +1,88 @@
+name: CI (Python)
+
+# Validates the Python packaging machinery against the most recent substrait
+# spec release. Attaches the released spec subtree and runs the same generate +
+# build + test steps as the Python publish workflows, but stops short of
+# versioning, committing, tagging and publishing — so a change that would break
+# a real release fails here first. Java and Rust are validated by ci_java.yml
+# and ci_rust.yml.
+
+on:
+  pull_request:
+    paths: &paths
+      - scripts/**
+      - pixi.toml
+      - pixi.lock
+      - python/**
+      - antlr/**
+      - testprotos.proto
+      - .github/workflows/ci_python.yml
+  push:
+    branches: [main]
+    paths: *paths
+  workflow_dispatch:
+    inputs:
+      substrait_version:
+        description: Substrait spec version to validate against (defaults to the latest release)
+        required: false
+        type: string
+
+concurrency:
+  group: ci-python-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Resolve Substrait Version
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OVERRIDE: ${{ github.event.inputs.substrait_version }}
+        run: |
+          if [ -n "$OVERRIDE" ]; then
+            VERSION="$OVERRIDE"
+          else
+            VERSION=$(./scripts/latest_release.sh)
+          fi
+          echo "Validating against substrait version: $VERSION"
+          echo "SUBSTRAIT_VERSION=$VERSION" >> "$GITHUB_ENV"
+      - name: Configure Git Identity
+        # attach_subtree.sh creates a squash commit, which needs an identity.
+        run: |
+          git config --global user.name 'substrait-packaging-ci'
+          git config --global user.email 'substrait-packaging-ci@users.noreply.github.com'
+      - name: Install pixi
+        uses: prefix-dev/setup-pixi@v0.9.6
+        with:
+          pixi-version: v0.62.2
+      - name: Attach substrait Spec Subtree
+        run: ./scripts/attach_subtree.sh
+      - name: Install substrait-antlr Dependencies
+        working-directory: python/substrait-antlr
+        run: pixi run uv sync --all-extras
+      - name: Generate substrait-antlr
+        run: pixi run python-generate-antlr
+      - name: Test substrait-antlr
+        working-directory: python/substrait-antlr
+        run: pixi run uv run pytest
+      - name: Install substrait-protobuf Dependencies
+        working-directory: python/substrait-protobuf
+        run: pixi run uv sync --all-extras
+      - name: Generate substrait-protobuf
+        run: pixi run python-generate-protobuf
+      - name: Test substrait-protobuf
+        working-directory: python/substrait-protobuf
+        run: pixi run uv run pytest
+      - name: Install substrait-extensions Dependencies
+        working-directory: python/substrait-extensions
+        run: pixi run uv sync --all-extras
+      - name: Generate substrait-extensions
+        run: pixi run python-generate-extensions
+      - name: Test substrait-extensions
+        working-directory: python/substrait-extensions
+        run: pixi run uv run pytest

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -1,0 +1,89 @@
+name: CI (Rust)
+
+# Validates the Rust packaging machinery against the most recent substrait spec
+# release. Attaches the released spec subtree and runs the same generate + build
+# + test steps as the Rust publish workflows, but stops short of versioning,
+# committing, tagging and publishing — so a change that would break a real
+# release fails here first. Java and Python are validated by ci_java.yml and
+# ci_python.yml.
+
+on:
+  pull_request:
+    paths: &paths
+      - scripts/**
+      - pixi.toml
+      - pixi.lock
+      - rust/**
+      - .github/workflows/ci_rust.yml
+  push:
+    branches: [main]
+    paths: *paths
+  workflow_dispatch:
+    inputs:
+      substrait_version:
+        description: Substrait spec version to validate against (defaults to the latest release)
+        required: false
+        type: string
+
+concurrency:
+  group: ci-rust-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rust:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Resolve Substrait Version
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OVERRIDE: ${{ github.event.inputs.substrait_version }}
+        run: |
+          if [ -n "$OVERRIDE" ]; then
+            VERSION="$OVERRIDE"
+          else
+            VERSION=$(./scripts/latest_release.sh)
+          fi
+          echo "Validating against substrait version: $VERSION"
+          echo "SUBSTRAIT_VERSION=$VERSION" >> "$GITHUB_ENV"
+      - name: Configure Git Identity
+        # attach_subtree.sh creates a squash commit, which needs an identity.
+        run: |
+          git config --global user.name 'substrait-packaging-ci'
+          git config --global user.email 'substrait-packaging-ci@users.noreply.github.com'
+      - name: Install pixi
+        uses: prefix-dev/setup-pixi@v0.9.6
+        with:
+          pixi-version: v0.62.2
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Attach substrait Spec Subtree
+        run: ./scripts/attach_subtree.sh
+      - name: Generate substrait-antlr
+        run: pixi run rust-generate-antlr
+      - name: Build and Test substrait-antlr
+        working-directory: rust/substrait-antlr
+        run: |
+          cargo build
+          cargo test
+      - name: Vendor substrait-prost
+        run: pixi run rust-generate-prost
+      - name: Build and Test substrait-prost
+        working-directory: rust/substrait-prost
+        run: |
+          cargo build --all-features
+          cargo test
+      - name: Package substrait-extensions
+        run: pixi run rust-generate-extensions
+      - name: Build and Test substrait-extensions
+        working-directory: rust/substrait-extensions
+        run: |
+          cargo build
+          cargo test

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Each of these workflows consumes a required substrait_version input. They are in
 
 The spec_released.yml workflow is a thin-wrapper around publish_artifacts.yml which is designed to be invoked whenever a new version of [substrait](https://github.com/substrait-io/substrait) specification is released.
 
+The ci_python.yml and ci_rust.yml workflows run on pull requests and pushes to `main`. They validate the packaging machinery against the most recent substrait spec release by running the same generate + build + test steps as the publish workflows, but without versioning, committing, tagging or publishing. This catches changes that would break a real release before they are merged. Each only runs when its language's relevant paths change (via a `paths` filter), and a specific spec version can be validated on demand via the `workflow_dispatch` `substrait_version` input.
+
 Re-usable scripts for use across these workflows can be found in `/scripts`.
 
 # Development

--- a/scripts/latest_release.sh
+++ b/scripts/latest_release.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eu
+
+# Print the tag name of the most recent substrait specification release
+# (e.g. v0.78.0). Used by CI to validate the packaging machinery against the
+# latest released spec version. Requires the `gh` CLI to be authenticated
+# (GH_TOKEN / GITHUB_TOKEN in CI).
+
+REPO="${1:-substrait-io/substrait}"
+
+gh api "repos/$REPO/releases/latest" --jq '.tag_name'


### PR DESCRIPTION
## What

Adds pull-request / push-to-`main` checks that verify the Python and Rust packaging machinery still builds the most recent substrait spec release. Until now nothing validated changes to the packaging code (generation scripts, `pixi.toml`, crate templates, etc.) until a real release was cut.

- **`ci_python.yml`** / **`ci_rust.yml`** — each resolves the latest substrait spec release, attaches it as the spec subtree, and runs the same *generate → build → test* steps as the corresponding publish workflows, but **stops short** of versioning, committing, tagging and publishing. No registry secrets, no `id-token`, no app token.
- **`scripts/latest_release.sh`** — small helper (matching the existing `scripts/` conventions) that resolves the latest spec release tag via `gh api`.

## Details

- Each workflow runs only when its language's relevant paths change (via a `paths` filter): Rust on `rust/**`; Python on `python/**`, plus the root `antlr/**` test YAMLs and `testprotos.proto` that its tests consume. Both also key on `scripts/**`, `pixi.toml`, `pixi.lock` and their own workflow file.
- A specific spec version can be validated on demand via the `workflow_dispatch` `substrait_version` input.
- The `pull_request` and `push` path filters are kept in sync via a YAML anchor.

## Note on required checks

Because these use a `paths` allowlist, they do **not** run for PRs that touch unrelated paths. If you mark the `python` / `rust` jobs as *required* status checks in branch protection, GitHub will treat a not-triggered required check as perpetually pending and block such PRs. Either leave them non-required, or add a small always-running gate job — happy to follow up with that.

A separate `ci_java.yml` is coming alongside the Java packaging work.

🤖 Generated with AI