### PR TITLE
fix(rust): pin substrait-extensions schemars to 0.8 to match typify

### DIFF
--- a/rust/substrait-extensions/Cargo.lock
+++ b/rust/substrait-extensions/Cargo.lock
@@ -134,26 +134,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ref-cast"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
-dependencies = [
- "ref-cast-impl",
-]
-
-[[package]]
-name = "ref-cast-impl"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "regress"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,20 +165,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
- "schemars_derive 0.8.22",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "schemars_derive 1.2.1",
+ "schemars_derive",
  "serde",
  "serde_json",
 ]
@@ -208,18 +175,6 @@ name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -326,7 +281,7 @@ dependencies = [
  "indexmap",
  "prettyplease",
  "regress",
- "schemars 1.2.1",
+ "schemars",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -387,7 +342,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regress",
- "schemars 0.8.22",
+ "schemars",
  "semver",
  "serde",
  "serde_json",
@@ -404,7 +359,7 @@ checksum = "d41aea893c49cf95661389207b8af0c6254ff48b2c3ae1e4f3704777dbdfcf03"
 dependencies = [
  "proc-macro2",
  "quote",
- "schemars 0.8.22",
+ "schemars",
  "semver",
  "serde",
  "serde_json",

--- a/rust/substrait-extensions/Cargo.toml
+++ b/rust/substrait-extensions/Cargo.toml
@@ -35,7 +35,10 @@ serde_yaml = "0.9.34"
 [build-dependencies]
 heck = "0.5.0"
 prettyplease = "0.2.37"
-schemars = "1.2.1"
+# Pinned to 0.8 to match the schemars version used by typify (0.7): build.rs
+# feeds schemars types straight into typify, so this must track typify's
+# schemars, not the latest release. Bumping to 1.x breaks the build.
+schemars = "0.8.22"
 serde_yaml = "0.9.34"
 syn = "2.0.111"
 typify = "0.7.0"


### PR DESCRIPTION
## Regression

PR #22 (a Dependabot \`build(deps): bump the rust-dependencies group\`) bumped the \`substrait-extensions\` build-dependency \`schemars\` from \`0.8.22\` to \`1.2.1\`. That broke the crate's build:

- \`build.rs\` uses the **schemars 0.8** API — \`schemars::schema::{RootSchema, Schema}\`, \`serde_yaml::from_reader::<_, RootSchema>(...)\`, \`Schema::Object(...)\` — and feeds those types straight into **typify 0.7.0**, which itself depends on \`schemars 0.8\`.
- Under \`schemars 1.x\` the \`schema\` module is private and \`RootSchema\` was removed, so the build script fails to compile (`E0432`/`E0603`).

There was no CI building the Rust crates at the time, so #22 merged broken on \`main\`.

## Fix

Pin \`schemars\` back to \`0.8.22\` (with a comment explaining it must track typify's schemars until typify is upgraded) and regenerate \`Cargo.lock\`, which drops the now-unused schemars 1.x subtree (\`schemars\`, \`schemars_derive\`, \`ref-cast\`, \`ref-cast-impl\`).

## Verification

Locally vendored the latest spec (v0.94.0) and ran a clean \`cargo build\` + \`cargo test\` for \`substrait-extensions\` — build succeeds, all text modules generate, all tests pass.

This is the regression that the Rust packaging CI in #23 caught; that PR will go green once this lands on \`main\`.

🤖 Generated with AI