### PR TITLE
feat(rust): expose raw extension YAML by URN and raw text schemas

### DIFF
--- a/rust/substrait-extensions/build.rs
+++ b/rust/substrait-extensions/build.rs
@@ -21,6 +21,7 @@ fn text(out_dir: &Path) -> Result<(), Box<dyn Error>> {
     use schemars::schema::{RootSchema, Schema};
     use typify::{TypeSpace, TypeSpaceSettings};
 
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);
     let mut out_file = File::create(out_dir.join("substrait_text").with_extension("rs"))?;
 
     for schema_path in WalkDir::new(TEXT_ROOT)
@@ -77,6 +78,29 @@ pub mod {title} {{
 }}"#,
             prettyplease::unparse(&syn::parse2::<syn::File>(type_space.to_stream())?),
         ))?;
+
+        // Also expose the raw schema source, so consumers that validate against
+        // the JSON schema (rather than the generated types) don't have to vendor
+        // it themselves. The const is named after the file stem, e.g.
+        // `simple_extensions_schema.yaml` -> `SIMPLE_EXTENSIONS_SCHEMA`.
+        let file_name = schema_path
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
+        let const_name = schema_path
+            .file_stem()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_uppercase();
+        out_file.write_fmt(format_args!(
+            r#"
+#[doc = "Raw source of the `{file_name}` text schema."]
+pub const {const_name}: &str = include_str!("{}/{}");
+"#,
+            manifest_dir.display(),
+            schema_path.display()
+        ))?;
     }
     Ok(())
 }
@@ -95,8 +119,10 @@ fn extensions(out_dir: &Path) -> Result<(), Box<dyn Error>> {
 // included in `extensions.rs`.
 "#,
     );
-    let mut map = HashMap::<String, String>::default();
-    for extension in WalkDir::new(EXTENSIONS_ROOT)
+    // Collect the extension files up front and sort them so the generated code
+    // (in particular the `SIMPLE_EXTENSIONS` slice below) is deterministic and
+    // independent of filesystem iteration order.
+    let mut extension_paths: Vec<PathBuf> = WalkDir::new(EXTENSIONS_ROOT)
         .into_iter()
         .filter_map(Result::ok)
         .filter(|entry| entry.file_type().is_file())
@@ -108,10 +134,16 @@ fn extensions(out_dir: &Path) -> Result<(), Box<dyn Error>> {
                 .is_some()
         })
         .map(DirEntry::into_path)
-        .inspect(|entry| {
-            println!("cargo:rerun-if-changed={}", entry.display());
-        })
-    {
+        .collect();
+    extension_paths.sort();
+
+    let mut map = HashMap::<String, String>::default();
+    // `(urn, const_name)` pairs in sorted order, for the `SIMPLE_EXTENSIONS`
+    // slice that maps each extension's URN to its raw YAML source.
+    let mut urns: Vec<(String, String)> = Vec::new();
+    for extension in &extension_paths {
+        println!("cargo:rerun-if-changed={}", extension.display());
+
         let name = extension
             .file_stem()
             .unwrap_or_default()
@@ -126,6 +158,17 @@ pub const {var_name}: &str = include_str!("{}/{}");
             manifest_dir.display(),
             extension.display()
         ));
+
+        // Extract the top-level `urn` field (a required property of every
+        // extension file) so the file can be looked up by its identifier.
+        let value = serde_yaml::from_str::<serde_yaml::Value>(&fs::read_to_string(extension)?)?;
+        let urn = value
+            .get("urn")
+            .and_then(serde_yaml::Value::as_str)
+            .unwrap_or_else(|| panic!("`urn` missing in `{}`", extension.display()))
+            .to_string();
+        urns.push((urn, var_name.clone()));
+
         map.insert(name, var_name);
     }
 
@@ -150,7 +193,31 @@ pub static EXTENSIONS: LazyLock<HashMap<&'static str, SimpleExtensions>> = LazyL
     output.push_str(
         r#"
     map
-});"#,
+});
+"#,
+    );
+
+    // Add a slice of every core extension as `(urn, raw YAML source)` pairs,
+    // keyed by the top-level `urn` field and referencing the raw-source consts
+    // emitted above. This lets consumers that work with the raw YAML (e.g. to
+    // validate against the JSON schema) enumerate and resolve extensions by URN
+    // without re-parsing.
+    output.push_str(
+        r#"
+/// All Substrait core extensions as `(urn, raw YAML source)` pairs, where `urn`
+/// is the value of the extension file's top-level `urn` field.
+pub static SIMPLE_EXTENSIONS: &[(&str, &str)] = &["#,
+    );
+    for (urn, var_name) in &urns {
+        output.push_str(&format!(
+            r#"
+    ("{urn}", {var_name}),"#
+        ));
+    }
+    output.push_str(
+        r#"
+];
+"#,
     );
 
     fs::write(substrait_extensions_file, output)?;

--- a/rust/substrait-extensions/src/lib.rs
+++ b/rust/substrait-extensions/src/lib.rs
@@ -10,12 +10,17 @@
 //! [releases](https://github.com/substrait-io/substrait/releases).
 //!
 //! - [`text`] — types generated from the text schemas (e.g.
-//!   [`text::simple_extensions::SimpleExtensions`]).
-//! - [`extensions`] — the embedded extension YAML files and an [`extensions::EXTENSIONS`]
-//!   lookup map.
+//!   [`text::simple_extensions::SimpleExtensions`]), plus the raw schema
+//!   sources as consts (e.g. `text::SIMPLE_EXTENSIONS_SCHEMA`) for consumers
+//!   that validate raw YAML against the JSON schema.
+//! - [`extensions`] — the embedded extension YAML files, the
+//!   [`extensions::EXTENSIONS`] map (keyed by file stem to the parsed
+//!   extension), and the [`extensions::SIMPLE_EXTENSIONS`] slice (keyed by URN
+//!   to the raw YAML source).
 //! - [`testcases`] — the embedded function test case files.
 
-/// Types generated from the Substrait text-based JSON schemas.
+/// Types generated from the Substrait text-based JSON schemas, plus the raw
+/// schema sources as `&str` consts (e.g. `SIMPLE_EXTENSIONS_SCHEMA`).
 #[allow(
     unused_variables,
     clippy::clone_on_copy,
@@ -42,6 +47,5 @@ pub mod testcases {
     use include_dir::{include_dir, Dir};
 
     /// The directory tree of `.test` function test case files.
-    pub static TESTCASES: Dir<'static> =
-        include_dir!("$CARGO_MANIFEST_DIR/testcases");
+    pub static TESTCASES: Dir<'static> = include_dir!("$CARGO_MANIFEST_DIR/testcases");
 }

--- a/rust/substrait-extensions/tests/extensions.rs
+++ b/rust/substrait-extensions/tests/extensions.rs
@@ -2,9 +2,10 @@
 
 //! Smoke tests for the packaged Substrait extension files.
 
-use substrait_extensions::extensions::{EXTENSIONS, FUNCTIONS_ARITHMETIC};
+use substrait_extensions::extensions::{EXTENSIONS, FUNCTIONS_ARITHMETIC, SIMPLE_EXTENSIONS};
 use substrait_extensions::testcases::TESTCASES;
 use substrait_extensions::text::simple_extensions::SimpleExtensions;
+use substrait_extensions::text::SIMPLE_EXTENSIONS_SCHEMA;
 
 #[test]
 fn arithmetic_extension_is_embedded_and_parses() {
@@ -24,6 +25,37 @@ fn lookup_map_contains_core_extensions() {
         .get("functions_arithmetic")
         .expect("functions_arithmetic present in EXTENSIONS");
     assert!(arithmetic.scalar_functions.iter().any(|f| f.name == "add"));
+}
+
+#[test]
+fn simple_extensions_slice_is_keyed_by_urn() {
+    // Every bundled extension appears in the URN-keyed slice, and the raw
+    // source it points at is the same const exposed individually.
+    assert_eq!(SIMPLE_EXTENSIONS.len(), EXTENSIONS.len());
+
+    let (urn, yaml) = SIMPLE_EXTENSIONS
+        .iter()
+        .find(|(urn, _)| *urn == "extension:io.substrait:functions_arithmetic")
+        .expect("functions_arithmetic present in SIMPLE_EXTENSIONS");
+    assert_eq!(*yaml, FUNCTIONS_ARITHMETIC);
+
+    // Each URN matches the parsed extension's own `urn` field, and the raw
+    // source parses into the generated type.
+    for (urn, yaml) in SIMPLE_EXTENSIONS {
+        let parsed: SimpleExtensions =
+            serde_yaml::from_str(yaml).expect("bundled extension parses");
+        assert_eq!(&parsed.urn, urn);
+    }
+    let _ = urn;
+}
+
+#[test]
+fn simple_extensions_schema_is_exposed() {
+    // The raw JSON schema source is available for consumers that validate raw
+    // YAML against it (rather than using the generated types).
+    assert!(SIMPLE_EXTENSIONS_SCHEMA.contains("urn"));
+    let _: serde_yaml::Value =
+        serde_yaml::from_str(SIMPLE_EXTENSIONS_SCHEMA).expect("schema is valid YAML");
 }
 
 #[test]


### PR DESCRIPTION
## What

Add two outputs to the `substrait-extensions` crate so consumers that work with the **raw YAML** — rather than the generated `SimpleExtensions` types — have everything they need:

- **`extensions::SIMPLE_EXTENSIONS: &[(&str, &str)]`** — every core extension as `(urn, raw YAML source)` pairs, keyed by the file's top-level `urn` field and referencing the existing raw-source consts. Sorted for deterministic output.
- **`text::SIMPLE_EXTENSIONS_SCHEMA`** (and `text::DIALECT_SCHEMA`) — the raw text-schema sources as `&str` consts.

## Why

A consumer doing schema-based validation (e.g. [substrait-validator](https://github.com/substrait-io/substrait-validator), which validates extension YAML — including user-supplied custom extensions — against the JSON schema and resolves the standard extensions offline by URN) needs:

1. to **enumerate** the bundled extensions and resolve them **by URN** to their raw YAML, and
2. the **raw schema text** to build a JSON-schema validator.

Today the crate exposes per-file raw consts (not enumerable) + the `EXTENSIONS` map (keyed by file *stem*, to *parsed* values), and the schema is vendored into the package but not exposed at runtime — so such a consumer still has to vendor the spec files itself. These two additions close that gap and let it drop its local copies entirely.

## How

Both are emitted by the existing content-driven `build.rs` codegen — the extension loop already has each file's stem and content in hand, and `text()` already opens each schema file. So they stay in sync with the vendored spec files automatically, with no per-release maintenance. `SIMPLE_EXTENSIONS` reads the `urn` field (a `required` top-level schema property) at build time; the extension paths are sorted so the generated slice is deterministic.

## Testing

`cargo test -p substrait-extensions` (after vendoring via `generate_extensions.sh`) — added tests assert the slice is URN-keyed, covers every extension, points at the same raw consts, that each entry's URN matches the parsed `urn`, and that the schema const is exposed and valid YAML. `cargo clippy --all-targets` and `cargo fmt` clean.

🤖 Generated with AI
