### PR TITLE
fix(rust): emit include_str! paths as escaped literals (Windows build)

### DIFF
--- a/rust/substrait-extensions/build.rs
+++ b/rust/substrait-extensions/build.rs
@@ -96,10 +96,9 @@ pub mod {title} {{
         out_file.write_fmt(format_args!(
             r#"
 #[doc = "Raw source of the `{file_name}` text schema."]
-pub const {const_name}: &str = include_str!("{}/{}");
+pub const {const_name}: &str = include_str!({:?});
 "#,
-            manifest_dir.display(),
-            schema_path.display()
+            manifest_dir.join(&schema_path)
         ))?;
     }
     Ok(())
@@ -150,13 +149,14 @@ fn extensions(out_dir: &Path) -> Result<(), Box<dyn Error>> {
             .to_string_lossy()
             .to_string();
         let var_name = name.to_uppercase();
+        // The path is emitted via `{:?}` (Debug) so that backslashes in
+        // Windows paths are escaped into a valid Rust string literal.
         output.push_str(&format!(
             r#"
 /// Included source of the `{name}` extension YAML file.
-pub const {var_name}: &str = include_str!("{}/{}");
+pub const {var_name}: &str = include_str!({:?});
 "#,
-            manifest_dir.display(),
-            extension.display()
+            manifest_dir.join(extension)
         ));
 
         // Extract the top-level `urn` field (a required property of every


### PR DESCRIPTION
## What

Fix a Windows build failure in `substrait-extensions`: `build.rs` generated `include_str!` arguments from the raw path `Display`, so on Windows the backslashes in the path were parsed by `rustc` as string escapes:

```
error: unknown character escape: `s`   (...\src\...)
error: unknown character escape: `U`   (...\Users\...)
error: could not compile `substrait-extensions` (lib) due to 119 previous errors
```

Emit the path via `{:?}` (Debug) instead, so backslashes are escaped into a valid Rust string literal on every platform. (On Unix the generated literal is unchanged.)

## Why it surfaced now

The crate's own CI builds on Linux, so this was latent. It first triggered when a consumer — [substrait-validator](https://github.com/substrait-io/substrait-validator/pull/529), which now depends on this crate — compiled it during its **Windows Python wheel** build.

## Scope

Applies to both the pre-existing per-file extension consts and the schema consts added in #25.

## Testing

`cargo build`/`cargo test`/`cargo clippy`/`cargo fmt --check` on the crate (Linux). The fix is platform-mechanical (`PathBuf` `Debug` escapes backslashes); the generated literal is byte-identical on Unix and becomes a valid escaped literal on Windows.

🤖 Generated with AI
