### PR TITLE
fix(ci): use inputs context for substrait_version in publish workflows

### DIFF
--- a/.github/workflows/ci_python.yml
+++ b/.github/workflows/ci_python.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Resolve Substrait Version
         env:
           GH_TOKEN: ${{ github.token }}
-          OVERRIDE: ${{ github.event.inputs.substrait_version }}
+          OVERRIDE: ${{ inputs.substrait_version }}
         run: |
           if [ -n "$OVERRIDE" ]; then
             VERSION="$OVERRIDE"

--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Resolve Substrait Version
         env:
           GH_TOKEN: ${{ github.token }}
-          OVERRIDE: ${{ github.event.inputs.substrait_version }}
+          OVERRIDE: ${{ inputs.substrait_version }}
         run: |
           if [ -n "$OVERRIDE" ]; then
             VERSION="$OVERRIDE"

--- a/.github/workflows/publish_artifacts.yml
+++ b/.github/workflows/publish_artifacts.yml
@@ -24,9 +24,9 @@ jobs:
     uses: ./.github/workflows/python_publish.yml
     secrets: inherit
     with:
-      substrait_version: ${{ github.event.inputs.substrait_version }}
+      substrait_version: ${{ inputs.substrait_version }}
   publish-rust-artifacts:
     uses: ./.github/workflows/rust_publish.yml
     secrets: inherit
     with:
-      substrait_version: ${{ github.event.inputs.substrait_version }}
+      substrait_version: ${{ inputs.substrait_version }}

--- a/.github/workflows/python_antlr.yml
+++ b/.github/workflows/python_antlr.yml
@@ -20,8 +20,8 @@ on:
         type: string
 
 env:
-  SUBSTRAIT_VERSION: ${{ github.event.inputs.substrait_version }}
-  TAG_NAME: "python/substrait-antlr/${{ github.event.inputs.substrait_version }}"
+  SUBSTRAIT_VERSION: ${{ inputs.substrait_version }}
+  TAG_NAME: "python/substrait-antlr/${{ inputs.substrait_version }}"
 
 jobs:
 

--- a/.github/workflows/python_extensions.yml
+++ b/.github/workflows/python_extensions.yml
@@ -20,8 +20,8 @@ on:
         type: string
 
 env:
-  SUBSTRAIT_VERSION: ${{ github.event.inputs.substrait_version }}
-  TAG_NAME: "python/substrait-extensions/${{ github.event.inputs.substrait_version }}"
+  SUBSTRAIT_VERSION: ${{ inputs.substrait_version }}
+  TAG_NAME: "python/substrait-extensions/${{ inputs.substrait_version }}"
 
 jobs:
 

--- a/.github/workflows/python_protobuf.yml
+++ b/.github/workflows/python_protobuf.yml
@@ -20,8 +20,8 @@ on:
         type: string
 
 env:
-  SUBSTRAIT_VERSION: ${{ github.event.inputs.substrait_version }}
-  TAG_NAME: "python/substrait-protobuf/${{ github.event.inputs.substrait_version }}"
+  SUBSTRAIT_VERSION: ${{ inputs.substrait_version }}
+  TAG_NAME: "python/substrait-protobuf/${{ inputs.substrait_version }}"
 
 jobs:
 

--- a/.github/workflows/python_publish.yml
+++ b/.github/workflows/python_publish.yml
@@ -24,14 +24,14 @@ jobs:
     uses: ./.github/workflows/python_antlr.yml
     secrets: inherit
     with:
-      substrait_version: ${{ github.event.inputs.substrait_version }}
+      substrait_version: ${{ inputs.substrait_version }}
   publish-python-protobuf:
     uses: ./.github/workflows/python_protobuf.yml
     secrets: inherit
     with:
-      substrait_version: ${{ github.event.inputs.substrait_version }}
+      substrait_version: ${{ inputs.substrait_version }}
   publish-python-extensions:
     uses: ./.github/workflows/python_extensions.yml
     secrets: inherit
     with:
-      substrait_version: ${{ github.event.inputs.substrait_version }}
+      substrait_version: ${{ inputs.substrait_version }}

--- a/.github/workflows/rust_antlr.yml
+++ b/.github/workflows/rust_antlr.yml
@@ -30,7 +30,7 @@ on:
         type: boolean
 
 env:
-  SUBSTRAIT_VERSION: ${{ github.event.inputs.substrait_version }}
+  SUBSTRAIT_VERSION: ${{ inputs.substrait_version }}
 
 jobs:
 

--- a/.github/workflows/rust_extensions.yml
+++ b/.github/workflows/rust_extensions.yml
@@ -30,7 +30,7 @@ on:
         type: boolean
 
 env:
-  SUBSTRAIT_VERSION: ${{ github.event.inputs.substrait_version }}
+  SUBSTRAIT_VERSION: ${{ inputs.substrait_version }}
 
 jobs:
 

--- a/.github/workflows/rust_prost.yml
+++ b/.github/workflows/rust_prost.yml
@@ -30,7 +30,7 @@ on:
         type: boolean
 
 env:
-  SUBSTRAIT_VERSION: ${{ github.event.inputs.substrait_version }}
+  SUBSTRAIT_VERSION: ${{ inputs.substrait_version }}
 
 jobs:
 

--- a/.github/workflows/rust_publish.yml
+++ b/.github/workflows/rust_publish.yml
@@ -34,17 +34,17 @@ jobs:
     uses: ./.github/workflows/rust_antlr.yml
     secrets: inherit
     with:
-      substrait_version: ${{ github.event.inputs.substrait_version }}
+      substrait_version: ${{ inputs.substrait_version }}
       alpha: ${{ inputs.alpha }}
   publish-rust-prost:
     uses: ./.github/workflows/rust_prost.yml
     secrets: inherit
     with:
-      substrait_version: ${{ github.event.inputs.substrait_version }}
+      substrait_version: ${{ inputs.substrait_version }}
       alpha: ${{ inputs.alpha }}
   publish-rust-extensions:
     uses: ./.github/workflows/rust_extensions.yml
     secrets: inherit
     with:
-      substrait_version: ${{ github.event.inputs.substrait_version }}
+      substrait_version: ${{ inputs.substrait_version }}
       alpha: ${{ inputs.alpha }}

--- a/.github/workflows/spec_released.yml
+++ b/.github/workflows/spec_released.yml
@@ -13,4 +13,4 @@ jobs:
     uses: ./.github/workflows/publish_artifacts.yml
     secrets: inherit
     with:
-      substrait_version: ${{ github.event.inputs.substrait_version }}
+      substrait_version: ${{ inputs.substrait_version }}


### PR DESCRIPTION
## What

Replace every `github.event.inputs.substrait_version` reference with the `inputs.substrait_version` context across the workflows, namely:

- `publish_artifacts.yml`, `spec_released.yml`
- `python_publish.yml` + leaf workflows (`python_antlr.yml`, `python_protobuf.yml`, `python_extensions.yml`)
- `rust_publish.yml` + leaf workflows (`rust_antlr.yml`, `rust_prost.yml`, `rust_extensions.yml`)
- `ci_python.yml`, `ci_rust.yml`

## Why

These workflows support `workflow_call` and/or `workflow_dispatch`. The `inputs` context is populated consistently for **both**, whereas `github.event.inputs` is only reliably populated for `workflow_dispatch` — under `workflow_call`, `github.event` is inherited from the *originating* event of the run, not repopulated with the inputs passed into the reusable workflow.

This matters most for the leaf workflows (`python_antlr.yml`, `rust_prost.yml`, etc.), which are normally invoked via `workflow_call` from their `*_publish.yml` aggregators — exactly the case where `github.event.inputs` is a latent bug. It happens to work today only because the chain always originates from a `workflow_dispatch` whose input shares the same name (`substrait_version`).

Using the `inputs` context removes the fragility and is the [documented approach](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows#using-inputs-and-secrets-in-a-reusable-workflow) for reusable workflows. It also matches `inputs.alpha` in `rust_publish.yml` and the `run-name` in `publish_artifacts.yml`, which already use the `inputs` context.

For the `ci_*` workflows, the `OVERRIDE` env evaluates empty on `pull_request`/`push` (no input passed) under both expressions, so behavior is unchanged; the fix only affects the `workflow_dispatch` path.

## Context

Spun out of review feedback on #19 (Java packaging), which flagged this pattern. That PR fixes the Java-specific files; this PR cleans up all pre-existing (already-merged) Python/Rust instances so the change stays out of the additive Java PR.

🤖 Generated with AI