### PR TITLE
feat(substrait-prost): expose prost::Name type names and optional reflection

### DIFF
--- a/rust/substrait-prost/Cargo.lock
+++ b/rust/substrait-prost/Cargo.lock
@@ -316,6 +316,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-reflect"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "590aa145fee8f7a26b5a6055365e7c5e89a5c1caae9869de76ec0ee73181a2f9"
+dependencies = [
+ "prost",
+ "prost-reflect-derive",
+ "prost-types",
+]
+
+[[package]]
+name = "prost-reflect-build"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8214ae2c30bbac390db0134d08300e770ef89b6d4e5abf855e8d300eded87e28"
+dependencies = [
+ "prost-build",
+ "prost-reflect",
+]
+
+[[package]]
+name = "prost-reflect-derive"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b6d90e29fa6c0d13c2c19ba5e4b3fb0efbf5975d27bcf4e260b7b15455bcabe"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,6 +484,8 @@ dependencies = [
  "pbjson-types",
  "prost",
  "prost-build",
+ "prost-reflect",
+ "prost-reflect-build",
  "prost-types",
  "protobuf-src",
  "serde",

--- a/rust/substrait-prost/Cargo.toml
+++ b/rust/substrait-prost/Cargo.toml
@@ -24,6 +24,10 @@ include = [
 default = []
 # Embed the protobuf file descriptor set for reflection.
 embed-descriptor = []
+# Derive `prost_reflect::ReflectMessage` for all message types, enabling runtime
+# protobuf introspection against the embedded descriptor set. Implies
+# `embed-descriptor`, which the generated reflection code reads at runtime.
+reflect = ["dep:prost-reflect", "dep:prost-reflect-build", "embed-descriptor"]
 # Build and vendor protoc from source for a consistent compiler across
 # platforms (used by docs.rs).
 protoc = ["dep:protobuf-src"]
@@ -35,6 +39,7 @@ serde = ["dep:pbjson", "dep:pbjson-build", "dep:pbjson-types", "dep:serde", "dep
 pbjson = { version = "0.9.0", optional = true }
 pbjson-types = { version = "0.9.0", optional = true }
 prost = "0.14.1"
+prost-reflect = { version = "0.16.4", features = ["derive"], optional = true }
 prost-types = "0.14.1"
 serde = { version = "1.0.228", features = ["derive"], optional = true }
 serde_json = { version = "1.0.145", features = ["preserve_order"], optional = true }
@@ -42,6 +47,7 @@ serde_json = { version = "1.0.145", features = ["preserve_order"], optional = tr
 [build-dependencies]
 pbjson-build = { version = "0.9.0", optional = true }
 prost-build = { version = "0.14.1", default-features = false }
+prost-reflect-build = { version = "0.16.0", optional = true }
 protobuf-src = { version = "2.1.1", optional = true }
 walkdir = "2.5.0"
 

--- a/rust/substrait-prost/build.rs
+++ b/rust/substrait-prost/build.rs
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use prost_build::Config;
-use std::{env, error::Error, path::PathBuf};
+use std::{
+    env,
+    error::Error,
+    path::{Path, PathBuf},
+};
 use walkdir::{DirEntry, WalkDir};
 
 // The Substrait `.proto` files are vendored into this directory by
@@ -9,14 +13,45 @@ use walkdir::{DirEntry, WalkDir};
 // compiled at build time.
 const PROTO_ROOT: &str = "proto";
 
+/// Applies the configuration shared by every build variant:
+///
+/// - the descriptor-set output path,
+/// - `prost::Name` impls (via `enable_type_names`) so consumers get
+///   authoritative fully-qualified type names instead of reconstructing them
+///   from Rust module paths, and
+/// - with the `reflect` feature, `prost_reflect::ReflectMessage` derives that
+///   read the crate's embedded `FILE_DESCRIPTOR_SET` for runtime introspection.
+fn configure_common(
+    config: &mut Config,
+    protos: &[impl AsRef<Path>],
+    descriptor_path: &Path,
+) -> Result<(), Box<dyn Error>> {
+    config.file_descriptor_set_path(descriptor_path);
+    config.enable_type_names();
+
+    #[cfg(feature = "reflect")]
+    prost_reflect_build::Builder::new()
+        .file_descriptor_set_path(descriptor_path)
+        .file_descriptor_set_bytes("crate::FILE_DESCRIPTOR_SET")
+        .configure(config, protos, &[PROTO_ROOT])?;
+
+    // `protos` is only consumed by the `reflect` builder above.
+    let _ = protos;
+
+    Ok(())
+}
+
 #[cfg(feature = "serde")]
 /// Serialize and deserialize implementations for proto types using `pbjson`.
-fn serde(protos: &[impl AsRef<std::path::Path>], descriptor_path: PathBuf) -> Result<(), Box<dyn Error>> {
+fn serde(
+    protos: &[impl AsRef<std::path::Path>],
+    descriptor_path: PathBuf,
+) -> Result<(), Box<dyn Error>> {
     use pbjson_build::Builder;
     use std::fs;
 
     let mut cfg = Config::new();
-    cfg.file_descriptor_set_path(&descriptor_path);
+    configure_common(&mut cfg, protos, &descriptor_path)?;
     cfg.compile_well_known_types()
         .extern_path(".google.protobuf", "::pbjson_types")
         .compile_protos(protos, &[PROTO_ROOT])?;
@@ -63,9 +98,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     serde(&protos, descriptor_path)?;
 
     #[cfg(not(feature = "serde"))]
-    Config::new()
-        .file_descriptor_set_path(&descriptor_path)
-        .compile_protos(&protos, &[PROTO_ROOT])?;
+    {
+        let mut config = Config::new();
+        configure_common(&mut config, &protos, &descriptor_path)?;
+        config.compile_protos(&protos, &[PROTO_ROOT])?;
+    }
 
     Ok(())
 }

--- a/rust/substrait-prost/tests/proto.rs
+++ b/rust/substrait-prost/tests/proto.rs
@@ -32,3 +32,34 @@ fn extensions_package_is_available() {
     };
     assert_eq!(urn.extension_urn_anchor, 1);
 }
+
+// `enable_type_names()` gives every message an authoritative fully-qualified
+// name via `prost::Name`, replacing module-path reconstruction downstream.
+#[test]
+fn message_type_names_are_authoritative() {
+    use prost::Name;
+    assert_eq!(Plan::full_name(), "substrait.Plan");
+    assert_eq!(Plan::PACKAGE, "substrait");
+    // Nested messages carry their enclosing scope in the name.
+    assert_eq!(
+        substrait_prost::r#type::List::full_name(),
+        "substrait.Type.List"
+    );
+}
+
+// With the `reflect` feature, messages derive `ReflectMessage`, resolving their
+// descriptor from the embedded `FILE_DESCRIPTOR_SET` at runtime.
+#[cfg(feature = "reflect")]
+#[test]
+fn reflect_message_descriptor_resolves() {
+    use prost_reflect::ReflectMessage;
+
+    let plan = Plan::default();
+    let descriptor = plan.descriptor();
+    assert_eq!(descriptor.full_name(), "substrait.Plan");
+    // The descriptor knows the message's fields by name.
+    assert!(descriptor.get_field_by_name("version").is_some());
+    // The embedded descriptor set is self-contained (imports resolved).
+    let pool = descriptor.parent_pool();
+    assert!(pool.get_message_by_name("substrait.Type.List").is_some());
+}


### PR DESCRIPTION
## What

Adds two neutral protobuf-introspection capabilities to the generated `substrait-prost` bindings:

- **`prost::Name` for every message** — `build.rs` now calls `prost_build::Config::enable_type_names()` unconditionally (no new dependencies). Consumers get an authoritative fully-qualified name (e.g. `Plan::full_name() == "substrait.Plan"`) instead of reconstructing it from Rust module paths.
- **Optional `reflect` feature** — derives `prost_reflect::ReflectMessage` for all messages, wired to the crate's embedded `FILE_DESCRIPTOR_SET`, enabling runtime introspection (field enumeration, descriptor lookup) without embedding the descriptor twice. The feature implies `embed-descriptor`.

## Why

Downstream crates want protobuf introspection over these types. In particular, [`substrait-validator`](https://github.com/substrait-io/substrait-validator) is migrating to consume `substrait-prost` (substrait-validator#531) and is exploring driving its traversal via `prost::Name` + `prost-reflect` (substrait-validator#538) rather than reverse-engineering prost's code generation at build time.

Because the validator's own introspection traits can only be derived on locally-generated types, consuming `substrait-prost`'s *foreign* types requires those types to carry the introspection impls themselves. Unlike the validator's engine-coupled `ProtoMeta` derive, `prost::Name` and `prost-reflect` are neutral, widely-used, standard-ecosystem traits with zero downstream coupling — so they belong here.

## Implementation

- Shared `configure_common` helper in `build.rs` applies the descriptor-set path, `enable_type_names()`, and (under `reflect`) the `prost_reflect_build::Builder` on both the serde and non-serde compilation paths.
- New `reflect = ["dep:prost-reflect", "dep:prost-reflect-build", "embed-descriptor"]` feature; `prost-reflect` (with `derive`) as an optional normal dep, `prost-reflect-build` as an optional build dep.

## Verification

- Generated code contains 170 `prost::Name` impls and 170 `ReflectMessage` derives, all referencing `crate::FILE_DESCRIPTOR_SET`.
- Builds clean across all feature combos: default, `embed-descriptor`, `reflect`, `serde`, `serde,reflect`.
- `cargo clippy` and `cargo fmt --check` clean.
- New tests in `tests/proto.rs` cover `prost::Name` names (including nested `substrait.Type.List`) and, under `reflect`, runtime descriptor resolution proving the embedded descriptor set is self-contained.

🤖 Generated with AI