### PR TITLE
feat(cpp): support an external ANTLR runtime and align exported target names

### DIFF
--- a/cpp/substrait-antlr/CMakeLists.txt
+++ b/cpp/substrait-antlr/CMakeLists.txt
@@ -24,6 +24,12 @@ set(SUBSTRAIT_ANTLR_VERSION
 option(SUBSTRAIT_ANTLR_USE_EXISTING_RUNTIME
        "Link an antlr4 runtime target provided by the parent project" OFF)
 
+# Set to ON below only when this project imports the ANTLR C++ runtime as an
+# installed package (via find_package) rather than building it hermetically or
+# reusing a parent target. The installed package config uses it to decide
+# whether to re-find that runtime for downstream find_package() consumers.
+set(SUBSTRAIT_ANTLR_IMPORT_RUNTIME_PACKAGE OFF)
+
 if(NOT SUBSTRAIT_ANTLR_USE_EXISTING_RUNTIME)
   include(FetchContent)
   set(ANTLR_BUILD_CPP_TESTS
@@ -51,6 +57,14 @@ if(NOT SUBSTRAIT_ANTLR_USE_EXISTING_RUNTIME)
     GIT_SHALLOW TRUE
     SOURCE_SUBDIR runtime/Cpp)
   FetchContent_MakeAvailable(antlr4_runtime)
+elseif(NOT TARGET antlr4_static AND NOT TARGET antlr4_shared)
+  # No parent-provided runtime target: import one as an installed package. The
+  # vcpkg `antlr4` port (and other packagers) ship the `antlr4-runtime` CMake
+  # config with an antlr4_static (static triplets) or antlr4_shared (dynamic
+  # triplets) target. Building the runtime via FetchContent here is not always
+  # possible (e.g. vcpkg isolates the network during builds).
+  find_package(antlr4-runtime CONFIG REQUIRED)
+  set(SUBSTRAIT_ANTLR_IMPORT_RUNTIME_PACKAGE ON)
 endif()
 
 # Compile the committed, generated parser sources.
@@ -67,7 +81,17 @@ endif()
 
 add_library(substrait_antlr ${SUBSTRAIT_ANTLR_SOURCES})
 add_library(substrait::antlr ALIAS substrait_antlr)
-target_link_libraries(substrait_antlr PUBLIC antlr4_static)
+# Export as substrait::antlr (matching the build-tree ALIAS) for find_package()
+# consumers, instead of the default substrait::substrait_antlr.
+set_target_properties(substrait_antlr PROPERTIES EXPORT_NAME antlr)
+# The ANTLR runtime target name depends on how it was provided: the hermetic
+# FetchContent build and static triplets expose antlr4_static; dynamic triplets
+# expose antlr4_shared.
+if(TARGET antlr4_shared)
+  target_link_libraries(substrait_antlr PUBLIC antlr4_shared)
+else()
+  target_link_libraries(substrait_antlr PUBLIC antlr4_static)
+endif()
 target_compile_features(substrait_antlr PUBLIC cxx_std_17)
 target_include_directories(
   substrait_antlr

--- a/cpp/substrait-antlr/cmake/SubstraitAntlrConfig.cmake.in
+++ b/cpp/substrait-antlr/cmake/SubstraitAntlrConfig.cmake.in
@@ -1,5 +1,15 @@
 @PACKAGE_INIT@
 
+# When this package was built against an ANTLR C++ runtime imported as an
+# installed package (find_package(antlr4-runtime)), the exported substrait_antlr
+# target links that runtime's antlr4_static/antlr4_shared target, so consumers
+# must be able to import it too. Hermetic (FetchContent) and parent-provided
+# builds leave this unset and need no such dependency.
+if(@SUBSTRAIT_ANTLR_IMPORT_RUNTIME_PACKAGE@)
+  include(CMakeFindDependencyMacro)
+  find_dependency(antlr4-runtime)
+endif()
+
 include("${CMAKE_CURRENT_LIST_DIR}/SubstraitAntlrTargets.cmake")
 
 check_required_components(SubstraitAntlr)

--- a/cpp/substrait-extensions/CMakeLists.txt
+++ b/cpp/substrait-extensions/CMakeLists.txt
@@ -18,6 +18,9 @@ set(SUBSTRAIT_EXTENSIONS_DATA_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 
 add_library(substrait_extensions INTERFACE)
 add_library(substrait::extensions ALIAS substrait_extensions)
+# Export as substrait::extensions (matching the build-tree ALIAS) for
+# find_package() consumers, instead of substrait::substrait_extensions.
+set_target_properties(substrait_extensions PROPERTIES EXPORT_NAME extensions)
 
 # Exposed to consumers (build tree). The install-tree path is set by the
 # package config file for find_package() consumers.

--- a/cpp/substrait-protobuf/CMakeLists.txt
+++ b/cpp/substrait-protobuf/CMakeLists.txt
@@ -37,6 +37,9 @@ file(MAKE_DIRECTORY "${SUBSTRAIT_PROTO_GEN_DIR}")
 
 add_library(substrait_proto)
 add_library(substrait::proto ALIAS substrait_proto)
+# Export as substrait::proto (matching the build-tree ALIAS) for find_package()
+# consumers, instead of the default substrait::substrait_proto.
+set_target_properties(substrait_proto PROPERTIES EXPORT_NAME proto)
 
 # Generate the C++ sources into the build tree and attach them to the target.
 protobuf_generate(


### PR DESCRIPTION
Two CMake improvements to the C++ package sources so package managers (notably vcpkg, which isolates the network during builds and therefore cannot run the hermetic ANTLR-runtime `FetchContent`) can build + install the packages cleanly, and so `find_package` and `FetchContent` consumers see the **same** target names.

## Changes
- **`substrait-antlr` — consume an externally provided ANTLR runtime.** When `SUBSTRAIT_ANTLR_USE_EXISTING_RUNTIME=ON` and no `antlr4_static`/`antlr4_shared` target is already defined, import one via `find_package(antlr4-runtime CONFIG REQUIRED)` and link whichever the triplet provides. The installed `SubstraitAntlrConfig.cmake` emits `find_dependency(antlr4-runtime)` **only** in that case (guarded by a new `SUBSTRAIT_ANTLR_IMPORT_RUNTIME_PACKAGE` flag).
- **All three — align exported target names.** Add `set_target_properties(<tgt> PROPERTIES EXPORT_NAME <short>)` so `find_package` exposes `substrait::{proto,extensions,antlr}` (matching the build-tree `ALIAS`es). Previously `find_package` exposed `substrait::substrait_*` while `FetchContent` exposed the short names.

## Why the conditional dependency
The hermetic `FetchContent` path (this repo's CI: `cmake -S cpp/substrait-antlr` with `USE_EXISTING_RUNTIME` defaulting `OFF`) must be unaffected. An unconditional `find_dependency(antlr4-runtime)` would make a downstream `find_package(SubstraitAntlr)` of a hermetic install require the antlr4-runtime *package*, which that build does not produce. The flag emits the dependency only when we actually imported the runtime as a package. `EXPORT_NAME` affects only `install(EXPORT)`, not the build-tree `ALIAS`, so tests that link the alias are unaffected.

## Verified (arm64-osx)
- Hermetic path still configures via `FetchContent`; generated config renders `if(OFF)` (no dependency emitted).
- External-runtime path builds and a consumer links `substrait::{proto,extensions,antlr}` with a working `find_dependency(antlr4-runtime)` (config renders `if(ON)`).

## Notes
- Independent of the registry-automation PR.
- Once a release tag ships these changes, the vcpkg registry's `substrait-antlr` port can drop its runtime patches, and `find_package` target names become the short form from that version on (so pre-fix tags keep exposing `substrait::substrait_*`).

🤖 Generated with AI