### PR TITLE
ci(cpp): auto-register released C++ tags in the vcpkg registry

### DIFF
--- a/.github/workflows/cpp_antlr.yml
+++ b/.github/workflows/cpp_antlr.yml
@@ -126,3 +126,15 @@ jobs:
         run: |
           git tag -a "$TAG_NAME" -m "$TAG_NAME"
           git push origin "$TAG_NAME"
+
+  # Register the freshly pushed tag in the vcpkg registry (bump the port, run
+  # vcpkg x-add-version, push to the registry branch). Runs only when a new tag
+  # was published, after the publish job succeeds.
+  cpp-antlr-registry:
+    needs: [cpp-antlr-prechecks, cpp-antlr-publish]
+    if: needs.cpp-antlr-prechecks.outputs.tag_exists == 'false'
+    uses: ./.github/workflows/cpp_registry.yml
+    secrets: inherit
+    with:
+      package: substrait-antlr
+      version: ${{ needs.cpp-antlr-prechecks.outputs.publish_version }}

--- a/.github/workflows/cpp_extensions.yml
+++ b/.github/workflows/cpp_extensions.yml
@@ -124,3 +124,15 @@ jobs:
         run: |
           git tag -a "$TAG_NAME" -m "$TAG_NAME"
           git push origin "$TAG_NAME"
+
+  # Register the freshly pushed tag in the vcpkg registry (bump the port, run
+  # vcpkg x-add-version, push to the registry branch). Runs only when a new tag
+  # was published, after the publish job succeeds.
+  cpp-extensions-registry:
+    needs: [cpp-extensions-prechecks, cpp-extensions-publish]
+    if: needs.cpp-extensions-prechecks.outputs.tag_exists == 'false'
+    uses: ./.github/workflows/cpp_registry.yml
+    secrets: inherit
+    with:
+      package: substrait-extensions
+      version: ${{ needs.cpp-extensions-prechecks.outputs.publish_version }}

--- a/.github/workflows/cpp_protobuf.yml
+++ b/.github/workflows/cpp_protobuf.yml
@@ -124,3 +124,15 @@ jobs:
         run: |
           git tag -a "$TAG_NAME" -m "$TAG_NAME"
           git push origin "$TAG_NAME"
+
+  # Register the freshly pushed tag in the vcpkg registry (bump the port, run
+  # vcpkg x-add-version, push to the registry branch). Runs only when a new tag
+  # was published, after the publish job succeeds.
+  cpp-protobuf-registry:
+    needs: [cpp-protobuf-prechecks, cpp-protobuf-publish]
+    if: needs.cpp-protobuf-prechecks.outputs.tag_exists == 'false'
+    uses: ./.github/workflows/cpp_registry.yml
+    secrets: inherit
+    with:
+      package: substrait-protobuf
+      version: ${{ needs.cpp-protobuf-prechecks.outputs.publish_version }}

--- a/.github/workflows/cpp_registry.yml
+++ b/.github/workflows/cpp_registry.yml
@@ -1,0 +1,130 @@
+name: Update C++ vcpkg Registry
+run-name: Register ${{ inputs.package }} ${{ inputs.version }} in the vcpkg registry
+
+# Serialize per package (not across all three): different packages push
+# independently and the publish job's retry loop re-syncs on contention, while
+# two runs for the *same* package never race the versions DB. A single shared
+# group would be unsafe — GitHub keeps only one pending run per group, so a third
+# concurrent member would cancel the pending one and drop a registration.
+concurrency:
+  group: cpp-registry-${{ inputs.package }}
+  cancel-in-progress: false
+
+on:
+  workflow_call:
+    inputs:
+      package:
+        description: Port to register (substrait-protobuf | substrait-antlr | substrait-extensions)
+        required: true
+        type: string
+      version:
+        description: Published version, e.g. 0.96.0-alpha (no leading 'v')
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      package:
+        description: Port to register (substrait-protobuf | substrait-antlr | substrait-extensions)
+        required: true
+        type: string
+      version:
+        description: Published version, e.g. 0.96.0-alpha (no leading 'v')
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+
+  # Gate: build the bumped port through vcpkg on each triplet before publishing,
+  # so a stale antlr patch or a diverged upstream CMakeLists fails here instead
+  # of landing a broken version in the registry. (windows-latest additionally
+  # exercises the dynamic-linkage antlr4_shared path; add it if release latency
+  # allows.)
+  verify:
+    name: Verify port (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout scripts
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Checkout registry branch
+        uses: actions/checkout@v7
+        with:
+          ref: vcpkg-registry
+          path: registry
+          persist-credentials: false
+      - name: Resolve release tag commit
+        id: tag
+        run: |
+          TAG="cpp/${{ inputs.package }}/v${{ inputs.version }}"
+          git -C registry fetch --no-tags origin "refs/tags/${TAG}:refs/tags/${TAG}"
+          echo "sha=$(git -C registry rev-parse "${TAG}^{}")" >> "$GITHUB_OUTPUT"
+      - name: Bump port to the release
+        run: ./scripts/vcpkg/bump_port.sh "${{ inputs.package }}" "${{ inputs.version }}" "${{ steps.tag.outputs.sha }}" registry
+      - name: Export vcpkg binary-cache credentials
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+      - name: Build port through the overlay
+        env:
+          # Reuse built dependencies (protobuf/antlr4) across runs.
+          VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
+        run: |
+          "$VCPKG_INSTALLATION_ROOT/vcpkg" install "${{ inputs.package }}" \
+            --overlay-ports=registry/ports \
+            --x-install-root="$RUNNER_TEMP/vcpkg-installed"
+
+  # Bump the port, append the version (vcpkg x-add-version) and push to the
+  # registry branch. Serialized by the per-package concurrency group; the script
+  # additionally retries with a re-sync if the branch advanced under it.
+  publish:
+    name: Publish to the registry
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token for pushing to the registry branch
+        uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ secrets.PACKAGER_CLIENT_ID }}
+          private-key: ${{ secrets.PACKAGER_KEY }}
+      - name: Get GitHub App user id
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      - name: Configure git user
+        run: |
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+      - name: Checkout scripts
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Checkout registry branch
+        uses: actions/checkout@v7
+        with:
+          ref: vcpkg-registry
+          path: registry
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+      - name: Resolve release tag commit
+        id: tag
+        run: |
+          TAG="cpp/${{ inputs.package }}/v${{ inputs.version }}"
+          git -C registry fetch --no-tags origin "refs/tags/${TAG}:refs/tags/${TAG}"
+          echo "sha=$(git -C registry rev-parse "${TAG}^{}")" >> "$GITHUB_OUTPUT"
+      - name: Publish version to the registry branch
+        run: |
+          export VCPKG_ROOT="$VCPKG_INSTALLATION_ROOT"
+          ./scripts/vcpkg/publish_version.sh \
+            "${{ inputs.package }}" "${{ inputs.version }}" "${{ steps.tag.outputs.sha }}" registry

--- a/scripts/vcpkg/bump_port.sh
+++ b/scripts/vcpkg/bump_port.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+set -eu
+
+# Point a vcpkg port at a newly published C++ release: set its version and pin
+# its portfile REF to the release tag's dereferenced commit SHA. Used by the
+# registry-update automation (cpp_registry.yml); safe to run by hand too.
+#
+# It edits only the version and REF — it never touches a port's PATCHES. When an
+# upstream release first ships the CMake changes that the antlr patches carry
+# (see cpp/substrait-antlr), drop that port's PATCHES block by hand once; from
+# then on this script just bumps it like the others.
+
+if [ "$#" -lt 3 ] || [ "$#" -gt 4 ]; then
+  echo "Usage: $0 <package> <version> <commit-sha> [registry-dir]" >&2
+  echo "  e.g. $0 substrait-protobuf 0.96.0-alpha a59c0622... ." >&2
+  exit 1
+fi
+
+PACKAGE="$1"   # substrait-protobuf | substrait-antlr | substrait-extensions
+VERSION="$2"   # x.y.z[-alpha[.N]] (no leading 'v')
+SHA="$3"       # dereferenced (peeled) commit SHA of the annotated release tag
+REGISTRY_DIR="${4:-.}"
+
+# vcpkg_from_git needs the commit a tag points at, not the tag object; validate
+# it is a full 40-hex commit SHA so a tag-object SHA or short SHA can't slip in.
+if ! printf '%s' "$SHA" | grep -qE '^[0-9a-f]{40}$'; then
+  echo "Error: commit-sha must be a full 40-hex SHA, received: $SHA" >&2
+  exit 2
+fi
+
+# Match the tag/version grammar used elsewhere (see scripts/tag_exists.sh).
+if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-alpha(\.[0-9]+)?)?$'; then
+  echo "Error: version must be x.y.z[-alpha[.N]], received: $VERSION" >&2
+  exit 2
+fi
+
+PORT_DIR="$REGISTRY_DIR/ports/$PACKAGE"
+MANIFEST="$PORT_DIR/vcpkg.json"
+PORTFILE="$PORT_DIR/portfile.cmake"
+for f in "$MANIFEST" "$PORTFILE"; do
+  if [ ! -f "$f" ]; then
+    echo "Error: $f not found (is '$PACKAGE' a port under $REGISTRY_DIR/ports?)" >&2
+    exit 2
+  fi
+done
+
+# --- vcpkg.json: set the published version (semver, incl. -alpha pre-releases).
+tmp="$(mktemp)"
+jq --arg v "$VERSION" '.["version-semver"] = $v' "$MANIFEST" > "$tmp"
+mv "$tmp" "$MANIFEST"
+
+# --- portfile.cmake: repoint the REF line's SHA and its trailing tag comment.
+# Both port shapes keep the SHA and a `# cpp/<package>/vX.Y.Z` comment on the
+# REF line, whether or not a PATCHES block follows:
+#   REF <sha>) # cpp/substrait-protobuf/v0.89.0-alpha      (protobuf/extensions)
+#   REF <sha> # cpp/substrait-antlr/v0.89.0-alpha          (antlr, PATCHES below)
+SHA="$SHA" VERSION="$VERSION" PACKAGE="$PACKAGE" perl -i -pe '
+  next unless /^\s*REF\s+[0-9a-f]{40}\b/;
+  s/[0-9a-f]{40}/$ENV{SHA}/;
+  s{(#\s*cpp/\Q$ENV{PACKAGE}\E/v)[^\s)]+}{$1 . $ENV{VERSION}}e;
+' "$PORTFILE"
+
+# Fail loudly if the REF did not end up as requested (e.g. an unexpected portfile
+# shape) rather than silently publishing a stale pin.
+if ! grep -qE "^\s*REF\s+$SHA\b" "$PORTFILE"; then
+  echo "Error: failed to set REF to $SHA in $PORTFILE" >&2
+  exit 3
+fi
+
+echo "Bumped $PACKAGE -> $VERSION @ $SHA"

--- a/scripts/vcpkg/publish_version.sh
+++ b/scripts/vcpkg/publish_version.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+set -eu
+
+# Publish a C++ release to the vcpkg registry branch: bump the port, append the
+# version to the versions DB (vcpkg x-add-version), and push to the registry
+# branch. Idempotent, and safe to run concurrently for different packages — on a
+# rejected push it re-syncs to the remote branch tip and re-applies, so the
+# per-package runs of a spec release serialize onto the branch without conflicts
+# (the shared versions/baseline.json is regenerated from the current tip each
+# time rather than textually merged).
+#
+# Run from a checkout of the registry branch whose `origin` is the packaging
+# repo. Requires VCPKG_ROOT set (for `vcpkg x-add-version`) and push credentials
+# configured on `origin`.
+
+if [ "$#" -lt 3 ] || [ "$#" -gt 4 ]; then
+  echo "Usage: $0 <package> <version> <commit-sha> [registry-dir]" >&2
+  exit 1
+fi
+
+PACKAGE="$1"
+VERSION="$2"
+SHA="$3"
+REGISTRY_DIR="${4:-.}"
+
+REGISTRY_BRANCH="${REGISTRY_BRANCH:-vcpkg-registry}"
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-5}"
+VCPKG="${VCPKG_ROOT:?VCPKG_ROOT must be set}/vcpkg"
+SCRIPT_DIR="$(dirname -- "$0")"
+SCRIPT_DIR="$(cd -- "$SCRIPT_DIR" && pwd)"
+
+cd "$REGISTRY_DIR"
+
+attempt=0
+while :; do
+  attempt=$((attempt + 1))
+
+  # Re-sync to the current remote tip so a bump computed against a stale base is
+  # discarded and recomputed (this is what makes concurrent per-package runs safe).
+  git fetch --quiet origin "$REGISTRY_BRANCH"
+  git reset --quiet --hard "origin/$REGISTRY_BRANCH"
+
+  "$SCRIPT_DIR/bump_port.sh" "$PACKAGE" "$VERSION" "$SHA" .
+
+  # Commit the port bump first: x-add-version reads the port's committed git-tree.
+  committed=0
+  if ! git diff --quiet -- "ports/$PACKAGE"; then
+    git add "ports/$PACKAGE"
+    git commit --quiet -m "publish $PACKAGE $VERSION to the vcpkg registry"
+    committed=1
+  fi
+
+  "$VCPKG" x-add-version "$PACKAGE" \
+    --x-builtin-ports-root=./ports \
+    --x-builtin-registry-versions-dir=./versions
+
+  if ! git diff --quiet -- versions; then
+    git add versions
+    if [ "$committed" = 1 ]; then
+      git commit --quiet --amend --no-edit   # fold the version entry into the bump commit
+    else
+      # Port was already current but the version entry was missing (e.g. a prior
+      # partial run) — commit the versions update on its own.
+      git commit --quiet -m "register $PACKAGE $VERSION in the vcpkg registry"
+      committed=1
+    fi
+  fi
+
+  if [ "$committed" = 0 ]; then
+    echo "$PACKAGE $VERSION already published; nothing to do"
+    exit 0
+  fi
+
+  if git push origin "HEAD:$REGISTRY_BRANCH"; then
+    echo "Published $PACKAGE $VERSION to $REGISTRY_BRANCH"
+    exit 0
+  fi
+
+  if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+    echo "Error: push to $REGISTRY_BRANCH still rejected after $attempt attempts" >&2
+    exit 1
+  fi
+  echo "Push rejected (branch advanced); re-syncing and retrying ($attempt/$MAX_ATTEMPTS)..." >&2
+done


### PR DESCRIPTION
Adds the last hop of C++ publishing: after `cpp_{protobuf,antlr,extensions}.yml` push a `cpp/<pkg>/vX.Y.Z` tag, register that release in the [`vcpkg-registry`](https://github.com/substrait-io/substrait-packaging/tree/vcpkg-registry) branch so downstream projects can resolve the new version via `find_package` instead of `FetchContent`.

## What's added
- **`scripts/vcpkg/bump_port.sh`** — point a port at a release: set `version-semver` and pin the portfile `REF` to the tag's dereferenced commit SHA. Never touches a port's `PATCHES`.
- **`scripts/vcpkg/publish_version.sh`** — bump + commit + `vcpkg x-add-version` + push to the registry branch. Idempotent, with a re-sync/retry loop so concurrent per-package runs serialize onto the branch without conflicting on the shared `versions/baseline.json`.
- **`.github/workflows/cpp_registry.yml`** — reusable workflow:
  - `verify` (ubuntu + macos): overlay-build the bumped port as a gate, so a stale patch or diverged upstream `CMakeLists` fails here instead of publishing a broken version.
  - `publish`: push via the packager GitHub App.
  - **Per-package** concurrency group — a single shared group would be unsafe (GitHub keeps only one pending run per group, so a third concurrent member would cancel the pending one and drop a registration).
- Each `cpp_<pkg>.yml` calls it after its publish job, gated on `tag_exists == 'false'`.

## Verified locally (arm64-osx, against real 0.96.0-alpha tags)
- `bump_port.sh`: correct for both port shapes, idempotent, shellcheck-clean.
- Overlay build of the bumped ports (the 0.89-authored antlr patches still apply to 0.96).
- `x-add-version` appends 0.96 while keeping 0.89 and advancing the baseline.
- `publish_version.sh`: publish, idempotent no-op, and the push-retry loop recovering from a forced non-fast-forward rejection (our commit lands on top of the competing commit).

## Requirements / notes
- Requires the `vcpkg-registry` branch to exist (already pushed). The automation maintains it (bump + append); it does not create ports from scratch.
- The packager GitHub App must be allowed to push to the `vcpkg-registry` branch.
- Works against today's patched ports; independent of the external-ANTLR-runtime CMake PR. When a post-that-PR tag ships, drop the antlr `PATCHES` from the registry port once (the `verify` gate flags it if forgotten).
- `workflow_dispatch` is available for manual backfill / re-registration.

🤖 Generated with AI