### PR TITLE
ci(cpp): default C++ publishes to final releases

### DIFF
--- a/.github/workflows/cpp_antlr.yml
+++ b/.github/workflows/cpp_antlr.yml
@@ -15,7 +15,7 @@ on:
       alpha:
         description: Publish an auto-incrementing alpha pre-release (-alpha, -alpha.1, ...)
         required: false
-        default: true
+        default: false
         type: boolean
   workflow_dispatch:
     inputs:
@@ -26,7 +26,7 @@ on:
       alpha:
         description: Publish an auto-incrementing alpha pre-release (-alpha, -alpha.1, ...)
         required: false
-        default: true
+        default: false
         type: boolean
 
 env:

--- a/.github/workflows/cpp_extensions.yml
+++ b/.github/workflows/cpp_extensions.yml
@@ -15,7 +15,7 @@ on:
       alpha:
         description: Publish an auto-incrementing alpha pre-release (-alpha, -alpha.1, ...)
         required: false
-        default: true
+        default: false
         type: boolean
   workflow_dispatch:
     inputs:
@@ -26,7 +26,7 @@ on:
       alpha:
         description: Publish an auto-incrementing alpha pre-release (-alpha, -alpha.1, ...)
         required: false
-        default: true
+        default: false
         type: boolean
 
 env:

--- a/.github/workflows/cpp_protobuf.yml
+++ b/.github/workflows/cpp_protobuf.yml
@@ -15,7 +15,7 @@ on:
       alpha:
         description: Publish an auto-incrementing alpha pre-release (-alpha, -alpha.1, ...)
         required: false
-        default: true
+        default: false
         type: boolean
   workflow_dispatch:
     inputs:
@@ -26,7 +26,7 @@ on:
       alpha:
         description: Publish an auto-incrementing alpha pre-release (-alpha, -alpha.1, ...)
         required: false
-        default: true
+        default: false
         type: boolean
 
 env:

--- a/.github/workflows/cpp_publish.yml
+++ b/.github/workflows/cpp_publish.yml
@@ -15,7 +15,7 @@ on:
       alpha:
         description: Publish an auto-incrementing alpha pre-release (-alpha, -alpha.1, ...)
         required: false
-        default: true
+        default: false
         type: boolean
   workflow_dispatch:
     inputs:
@@ -26,7 +26,7 @@ on:
       alpha:
         description: Publish an auto-incrementing alpha pre-release (-alpha, -alpha.1, ...)
         required: false
-        default: true
+        default: false
         type: boolean
 
 jobs:


### PR DESCRIPTION
## What

Flip the `alpha` input default from `true` to `false` across all four C++ publish workflows — `cpp_publish.yml`, `cpp_protobuf.yml`, `cpp_antlr.yml`, `cpp_extensions.yml` — on both the `workflow_call` and `workflow_dispatch` triggers.

## Why

The spec-release pipeline (`spec_released` → `publish_artifacts` → `cpp_publish`) does not forward an `alpha` input, so it inherits the leaf-workflow default. With the default at `true`, C++ artifacts were published as auto-incrementing `-alpha` pre-releases (`x.y.z-alpha`, `x.y.z-alpha.1`, …). Flipping it to `false` makes the pipeline publish final `x.y.z` releases by default.

## Behavior change

- Spec-release runs now publish final C++ releases instead of alpha pre-releases.
- Manual `workflow_dispatch` runs default the `alpha` checkbox to off.
- To cut an alpha, explicitly pass `alpha: true`.

## Notes / out of scope

- Rust is unchanged — its `alpha` default stays `true` (documented in `rust/README.md`).
- `publish_artifacts.yml` still doesn't forward `alpha`, so relying on the leaf default is sufficient; no wiring change needed.

🤖 Generated with AI