### PR TITLE
ci(java): temporarily disable Java publishing in release pipeline

### DIFF
--- a/.github/workflows/publish_artifacts.yml
+++ b/.github/workflows/publish_artifacts.yml
@@ -25,7 +25,12 @@ jobs:
     secrets: inherit
     with:
       substrait_version: ${{ inputs.substrait_version }}
+  # TEMPORARILY DISABLED: Java publishing is blocked on a Maven Central Portal 403 while the
+  # `io.substrait` namespace is authorized for the publishing account. The Java workflows remain
+  # manually dispatchable (java_publish.yml / java_*.yml) so the fix can be verified. Re-enable by
+  # removing the `if: false` guard below once the Central Portal credentials/namespace are sorted.
   publish-java-artifacts:
+    if: false
     uses: ./.github/workflows/java_publish.yml
     secrets: inherit
     with:


### PR DESCRIPTION
## What

Guards the `publish-java-artifacts` fan-out job in `publish_artifacts.yml` with `if: false` so the automated release pipeline (`spec_released.yml` → `publish_artifacts.yml`) **skips Java publishing**. Python, Rust, and C++ publishing are unaffected.

## Why

A test run of the Java publish pipeline fails at the Maven Central Portal snapshot upload with:

```
Nmcp: cannot PUT '.../io/substrait/extensions/...-javadoc.jar'
HTTP error 403: ''
```

A `403` means the publishing account authenticates but is **not authorized for the `io.substrait` namespace** on the Central Portal (likely the namespace still needs to be migrated/claimed on the Portal, or the token's account added to it). Fixing that requires Central Portal / credential changes that will take some time, so this disables Java publishing in the meantime rather than letting every release fail on the Java leg.

## Scope

- **Only** the automated fan-out is disabled. `java_publish.yml` and `java_{antlr,protobuf,extensions}.yml` remain `workflow_dispatch`-able, so the credential/namespace fix can be verified manually before re-enabling.
- No changes to the Gradle build or signing config (those are working).

## Re-enabling

Remove the `if: false` guard (and the accompanying comment) on `publish-java-artifacts` once the Central Portal namespace/credentials are sorted.

🤖 Generated with AI