### PR TITLE
ci(java): re-enable Java publishing in release pipeline

### DIFF
--- a/.github/workflows/publish_artifacts.yml
+++ b/.github/workflows/publish_artifacts.yml
@@ -25,12 +25,7 @@ jobs:
     secrets: inherit
     with:
       substrait_version: ${{ inputs.substrait_version }}
-  # TEMPORARILY DISABLED: Java publishing is blocked on a Maven Central Portal 403 while the
-  # `io.substrait` namespace is authorized for the publishing account. The Java workflows remain
-  # manually dispatchable (java_publish.yml / java_*.yml) so the fix can be verified. Re-enable by
-  # removing the `if: false` guard below once the Central Portal credentials/namespace are sorted.
   publish-java-artifacts:
-    if: false
     uses: ./.github/workflows/java_publish.yml
     secrets: inherit
     with:


### PR DESCRIPTION
## What

Removes the `if: false` guard on the `publish-java-artifacts` job in `publish_artifacts.yml`, re-enabling Java publishing in the automated release pipeline (`spec_released.yml` → `publish_artifacts.yml` → `java_publish.yml`). Reverts the temporary disable from #47.

## Why

The Maven Central Portal 403 was a credentials/namespace-authorization issue for the `io.substrait` namespace, not a build problem. That has now been fixed, and a full Java publish ran green end-to-end:

- **Publish Java Artifacts for Version v0.98.0** — success: https://github.com/substrait-io/substrait-packaging/actions/runs/30080151709

The `publish-java-artifacts` job now matches its Python/Rust/C++ siblings exactly.

## Follow-up

`java_antlr.yml` still runs `publishAggregationToCentralSnapshots` with a `-SNAPSHOT` version (see the TODO in `java_antlr.yml`). Switching to `publishAggregationToCentralPortal` with a released (non-SNAPSHOT) version, to publish real releases to Maven Central, remains a separate follow-up.

🤖 Generated with AI