### PR TITLE
feat(java): bundle per-section dialect fixtures in the extensions artifact

### DIFF
--- a/java/extensions/build.gradle.kts
+++ b/java/extensions/build.gradle.kts
@@ -4,11 +4,13 @@ plugins {
 
 dependencies {}
 
-// No code generation: bundle the Substrait extension YAMLs, text schemas and function
-// test-case files from the attached spec subtree as classpath resources under `substrait/`.
+// No code generation: bundle the Substrait extension YAMLs, text schemas, function
+// test-case files and per-section dialect fixtures from the attached spec subtree as
+// classpath resources under `substrait/`.
 tasks.named<ProcessResources>("processResources") {
   val specDir = "${rootProject.projectDir}/../substrait"
   from("$specDir/extensions") { into("substrait/extensions") }
   from("$specDir/text") { into("substrait/text") }
   from("$specDir/tests/cases") { into("substrait/tests/cases") }
+  from("$specDir/dialects/tests") { into("substrait/dialects/tests") }
 }


### PR DESCRIPTION
## What

The `extensions` artifact bundles the spec's extension YAMLs, text schemas and function test-case files as classpath resources under `substrait/`, but not the per-section dialect fixtures. This adds them:

```kotlin
from("$specDir/dialects/tests") { into("substrait/dialects/tests") }
```

so the artifact ships `substrait/dialects/tests/{types,relations,expressions,functions,execution_behavior}_test.yaml` alongside the resources it already carries.

## Why

`substrait-java` still keeps the upstream spec as a `substrait` git submodule solely to read a handful of resources at build/test time. It already sources proto, ANTLR and extension YAMLs from these packaging artifacts; the per-section dialect fixtures are the **last** spec resource it reads directly from the submodule working tree. Shipping them here lets substrait-java drop the submodule entirely and source the whole spec from published artifacts.

## Validation

- `ci_java.yml` attaches the spec subtree and runs `:extensions:build`, so the new glob is exercised on this PR.
- Verified locally by publishing the extensions SNAPSHOT to Maven Local and confirming the jar contains all five `dialects/tests/*_test.yaml` fixtures; substrait-java's full reactor build then passes against it with the submodule removed.

🤖 Generated with AI