### PR TITLE
ci(java): publish releases to Maven Central instead of snapshots

### DIFF
--- a/.github/workflows/java_antlr.yml
+++ b/.github/workflows/java_antlr.yml
@@ -124,8 +124,4 @@ jobs:
           SIGNING_KEY_ID: ${{ secrets.M2_SIGNING_KEY_ID }}
           SIGNING_KEY: ${{ secrets.M2_SIGNING_KEY }}
           SIGNING_PASSWORD: ${{ secrets.M2_SIGNING_PASSWORD }}
-        # TODO: publish SNAPSHOTs while validating the release pipeline end-to-end (these can be
-        # consumed from the Central Snapshots repo, e.g. by substrait-java). Swap to
-        # `publishAggregationToCentralPortal` with a non-SNAPSHOT version in a follow-up to publish
-        # released artifacts to Maven Central.
-        run: ./gradlew publishAggregationToCentralSnapshots -PpublishArtifact=antlr -Pversion=${SUBSTRAIT_VERSION#v}-SNAPSHOT
+        run: ./gradlew publishAggregationToCentralPortal -PpublishArtifact=antlr -Pversion=${SUBSTRAIT_VERSION#v}

--- a/.github/workflows/java_extensions.yml
+++ b/.github/workflows/java_extensions.yml
@@ -124,8 +124,4 @@ jobs:
           SIGNING_KEY_ID: ${{ secrets.M2_SIGNING_KEY_ID }}
           SIGNING_KEY: ${{ secrets.M2_SIGNING_KEY }}
           SIGNING_PASSWORD: ${{ secrets.M2_SIGNING_PASSWORD }}
-        # TODO: publish SNAPSHOTs while validating the release pipeline end-to-end (these can be
-        # consumed from the Central Snapshots repo, e.g. by substrait-java). Swap to
-        # `publishAggregationToCentralPortal` with a non-SNAPSHOT version in a follow-up to publish
-        # released artifacts to Maven Central.
-        run: ./gradlew publishAggregationToCentralSnapshots -PpublishArtifact=extensions -Pversion=${SUBSTRAIT_VERSION#v}-SNAPSHOT
+        run: ./gradlew publishAggregationToCentralPortal -PpublishArtifact=extensions -Pversion=${SUBSTRAIT_VERSION#v}

--- a/.github/workflows/java_protobuf.yml
+++ b/.github/workflows/java_protobuf.yml
@@ -124,8 +124,4 @@ jobs:
           SIGNING_KEY_ID: ${{ secrets.M2_SIGNING_KEY_ID }}
           SIGNING_KEY: ${{ secrets.M2_SIGNING_KEY }}
           SIGNING_PASSWORD: ${{ secrets.M2_SIGNING_PASSWORD }}
-        # TODO: publish SNAPSHOTs while validating the release pipeline end-to-end (these can be
-        # consumed from the Central Snapshots repo, e.g. by substrait-java). Swap to
-        # `publishAggregationToCentralPortal` with a non-SNAPSHOT version in a follow-up to publish
-        # released artifacts to Maven Central.
-        run: ./gradlew publishAggregationToCentralSnapshots -PpublishArtifact=protobuf -Pversion=${SUBSTRAIT_VERSION#v}-SNAPSHOT
+        run: ./gradlew publishAggregationToCentralPortal -PpublishArtifact=protobuf -Pversion=${SUBSTRAIT_VERSION#v}


### PR DESCRIPTION
## What

Switches the Java publish workflows from publishing **SNAPSHOT** artifacts to the Central Snapshots repository to publishing **released `x.y.z`** artifacts to **Maven Central**.

Across `java_protobuf.yml`, `java_antlr.yml` and `java_extensions.yml`, the publish step changes from:

```sh
./gradlew publishAggregationToCentralSnapshots -PpublishArtifact=<name> -Pversion=${SUBSTRAIT_VERSION#v}-SNAPSHOT
```

to:

```sh
./gradlew publishAggregationToCentralPortal -PpublishArtifact=<name> -Pversion=${SUBSTRAIT_VERSION#v}
```

and drops the accompanying `TODO` comment that described exactly this follow-up.

## Why

The snapshot publishing was a deliberately temporary state so the release pipeline could be validated end-to-end before cutting real releases. That validation is done: the SNAPSHOT artifacts were consumed successfully by `substrait-java` in substrait-io/substrait-java#1043.

## Notes

- No build-logic change is needed. The root `build.gradle.kts` already configures the Central Portal endpoint (`nmcpAggregation { centralPortal { ... publishingType = "AUTOMATIC" } }`) with the `MAVENCENTRAL_USERNAME` / `MAVENCENTRAL_PASSWORD` credentials and the PGP signing keys, all supplied via the `maven-central` environment secrets already wired into the publish jobs. `AUTOMATIC` means each upload is released to Central without a manual portal step.
- The per-artifact Maven Central existence precheck (`scripts/java/maven_central_package_exists.sh`) already probes the release URL (`repo1.maven.org/.../io/substrait/<artifact>/<version>/`), so it now correctly short-circuits a republish of an already-released version.
- The `README.md` publishing example already documents `publishAggregationToCentralPortal`, so no doc change is required.

## Validation

`./gradlew publishAggregationToCentralPortal -PpublishArtifact=protobuf -Pversion=0.98.0 --dry-run` resolves and reaches `:publishAggregationToCentralPortal` cleanly with a non-SNAPSHOT version.

🤖 Generated with AI